### PR TITLE
feat: get stars and forks as number

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ function ghPinnedRepos(username) {
       const owner =$(item).find('.owner').text()
       const repo = $(item).find('.repo').text()
       const stars = $(item)
-      .find('a[href$="/stargazers"]')
-      .text()
-      .trim()
+        .find('a[href$="/stargazers"]')
+        .text()
+        .trim()
       const forks = $(item)
         .find('a[href$="/network/members"]')
         .text()
@@ -41,8 +41,8 @@ function ghPinnedRepos(username) {
           .trim(),
         language: language || undefined,
         languageColor: languageColor || undefined,
-        stars: stars || 0,
-        forks: forks || 0
+        stars: parseInt(stars) || 0,
+        forks: parseInt(forks) || 0
       }
     })
     return result


### PR DESCRIPTION
I propose to return the number properties (`stars` and `forks`) as number :)
Currently, it's returned as string if there is a value, or 0 (so it's mixing up the types).

If a weird value is passed to `parseInt`, it will return `NaN` and be defaulted to `0`.

Note: I just hope nobody's relying heavily on this service because it's kinda a breaking change 😬