### PR TITLE
Fixed fork count

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function ghPinnedRepos(username) {
       .text()
       .trim()
       const forks = $(item)
-        .find('a[href$="/network/members"]')
+        .find('a[href$="/network"]')
         .text()
         .trim()
       const languageColor = $(item)


### PR DESCRIPTION
Updated link being searched for so fork count is now correct and doesn't always return 0. I assume GitHub changed where the fork button went to at some point.